### PR TITLE
fix: enable CI workflow for develop branch PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, develop ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   workflow_dispatch:
 
 env:


### PR DESCRIPTION
The CI workflow was only configured to run on PRs targeting main, but with our Git Flow strategy, most PRs target develop. This caused status checks to show 'Waiting for status to be reported' instead of actually running.

Now CI will run on:
- Pushes to main and develop branches
- PRs targeting main and develop branches
- Manual workflow dispatch

This ensures all feature/* and fix/* branch PRs to develop will properly trigger CI status checks.

🤖 Generated with [Claude Code](https://claude.ai/code)